### PR TITLE
Typo fix: messsage → message

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Options:
                        along with bold, underline, reverse, and combinations.
 --                     Signify end of options, so next argument is the pattern.
                        E.g. to search for "-x" in file foo.txt, use "lumin -- -x foo.txt".
--h|--help              Print this messsage.
+-h|--help              Print this message.
 ```

--- a/lumin.go
+++ b/lumin.go
@@ -47,7 +47,7 @@ Options:
                        along with bold, underline, reverse, and combinations.
 --                     Signify end of options, so next argument is the pattern.
                        E.g. to search for "-x" in file foo.txt, use "lumin -- -x foo.txt".
--h|--help              Print this messsage.
+-h|--help              Print this message.
 `,
 		os.Args[0], ENV_COLOR_NAME,
 	)


### PR DESCRIPTION
This turned up while preparing the Debian package (flagged by the
Lintian QA tool).

Signed-off-by: Stephen Kitt <steve@sk2.org>